### PR TITLE
Calibrate cell's forces inside the Master telemetria code

### DIFF
--- a/code/configurador.py
+++ b/code/configurador.py
@@ -92,6 +92,14 @@ class Configurador(object):
             "fte"
         ]
 
+        self.CALFACTS_DAS_CELULAS = [
+            629.0,
+            217.0,
+            192.0,
+            211.0,
+            210.0
+        ]
+
         # ARDUINO
         self.USAR_ARDUINO = True
 

--- a/code/criador.py
+++ b/code/criador.py
@@ -78,6 +78,7 @@ class Criador(object):
                 for i in range(self.configurador.NUMERO_DE_CELULAS):
                     self.celulas.append(Celula(self.configurador.NOME_DAS_CELULAS[i],
                                                 self.configurador.APELIDO_DAS_CELULAS[i],
+                                                self.configurador.CALFACTS_DAS_CELULAS[i],
                                                 self.arduino))
                 print('CELULAS ativadas!')
             except:

--- a/code/libs/celula.py
+++ b/code/libs/celula.py
@@ -4,9 +4,10 @@ class Celula(object):
     Esta classe ira receber e tratar os dados de força vindos
     de cada uma das células (através do Arduino)."""
 
-    def __init__(self, nome, apelido, arduino, UM = "N"):
+    def __init__(self, nome, apelido, cal_factor, arduino, UM = "N"):
         self.nome =  nome
         self.apelido = apelido
+        self.calibration_factor = cal_factor
         self.arduino = arduino
         self.UM = UM
         self.force = 0
@@ -14,7 +15,8 @@ class Celula(object):
     def atualiza(self):
         dicioDeDados = self.arduino.getData()
         if self.apelido in dicioDeDados:
-            self.force = dicioDeDados[self.apelido]
+            raw_force = dicioDeDados[self.apelido]
+            self.force = raw_force/self.calibration_factor
 
     def getForce(self):
         return self.force


### PR DESCRIPTION
**This is a change of concept, so very important.** 

Previous implementation assumed that the data coming from the Slave (Arduino) was already calibrated, so the Master only assumed it received correct values, on the correct unit, and used it.  This was to make sure the Slave was could be used by itself, without changes.

The problem with this previous implementation was that it didn't allow, or allowed on a messy way, to calibrate the forces inside Master. Doing this was kind of a ugly thing, because the Master would be calibrating an already calibrated  value. If something changed on Slave (and it could/should be changed), changes on Master would need to occur also.

To prevent the "shared own", all the calibration is being transferred to Master. This will be made with the Pitot and other sensors also. This new way prevent unknown changes to occur and make sure the Master can change things as it needs.

**From now on the Slave is just a "sensor middle-man", as it was supposed to be.**

Calibraton factors are now on Configurador(), so them can be changed both by the user and code as it needs. Those factors are passed to the Celulas() on initialization. For now they are fixed once the code is running, but this can be changed in the future with new methods.